### PR TITLE
A, B, C, D...P, Q, Find R

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 TinySpline
 ========
 
+[![Build Status](https://travis-ci.org/msteinbeck/tinyspline.svg?branch=master)](https://travis-ci.org/msteinbeck/tinyspline)
+
 TinySpline is library for NURBS, B-Splines, and Bézier curves giving you access to several
 operations on splines. The library has been implemented in C (C89) and provides a wrapper
 for C++ (C++11) along with bindings for C#, Java, Lua, PHP, Python, and Ruby. The focus of

--- a/library/cmake/Modules/FindR.cmake
+++ b/library/cmake/Modules/FindR.cmake
@@ -1,0 +1,62 @@
+# -*-cmake-*-
+#
+# Nightwave Studios - FindR.cmake
+# https://www.nightwave.co
+#
+# Search for R library files
+#
+# Once loaded this will define:
+#   R_FOUND       - system has R
+#   R_INCLUDE_DIR - include directory for R
+#   R_LIBRARY_DIR - library directory for R
+#   R_LIBRARIES   - libraries you need to link to
+
+
+
+# Find headers
+find_path(R_INCLUDE_DIR
+	NAMES "R.h"
+	PATHS
+	"[HKEY_LOCAL_MACHINE\\SOFTWARE\\R\\Current;BinPath]"
+	"$ENV{R_LOCATION}"
+	"$ENV{R_LOCATION}/include"
+	"$ENV{R_LOCATION}/include/R"
+	"$ENV{R_HOME}/include"
+	/usr/include/
+	/usr/include/R
+	/usr/local/include
+	/usr/local/include/R
+	/opt/local/include/R
+)
+
+# Find compiled library file
+find_library(R_LIBRARIES
+	NAMES libR R
+	PATHS 
+	"[HKEY_LOCAL_MACHINE\\SOFTWARE\\R\\Current;BinPath]"
+	"$ENV{R_LOCATION}/R/.libs"
+	"$ENV{R_LOCATION}/lib"
+	"$ENV{R_HOME}/lib"
+	/usr/lib64
+	/usr/local/lib64
+	/opt/local/lib64
+	/usr/lib
+	/usr/local/lib
+	/opt/local/lib
+	DOC "R library"
+)
+
+# Get path to library
+get_filename_component(R_LIBRARY_DIR ${R_LIBRARIES} PATH)
+
+# Set variables as advanced (hide from GUI unless "show advanced checked")
+mark_as_advanced(R_LIBRARIES R_LIBRARY_DIR R_INCLUDE_DIR)
+
+# Set R_FOUND and print message
+INCLUDE(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+	R
+	DEFAULT_MSG
+	R_LIBRARIES
+	R_INCLUDE_DIR
+)


### PR DESCRIPTION
And now that the string of commits about PHP have been merged, let's move on two more letters down the alphabet, to R!  This includes the `FindR.cmake` module that can be found in the [VaduNightwave/CMakeModules](https://github.com/VaduNightwave/CMakeModules) collection hosted by my studio.  :wink: