### PR TITLE
Create Travis CI buildscript (for macOS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+
+os:
+  # - linux
+  - osx
+
+compiler:
+  - gcc
+  - clang
+
+osx_image: xcode9.2
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/php; brew update; fi
+
+install:
+  # Install packages from Homebrew/Aptitude
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install swig php71 lua; fi
+
+before_script:
+  - mkdir build
+  - cd build
+  - then cmake .. -DTINYSPLINE_WITH_RUBY=FALSE
+
+script:
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 before_script:
   - mkdir build
   - cd build
-  - cmake .. -DTINYSPLINE_WITH_RUBY=FALSE
+  - cmake .. -DTINYSPLINE_WITH_RUBY=FALSE -DTINYSPLINE_WITH_PHP=FALSE
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 before_script:
   - mkdir build
   - cd build
-  - then cmake .. -DTINYSPLINE_WITH_RUBY=FALSE
+  - cmake .. -DTINYSPLINE_WITH_RUBY=FALSE
 
 script:
   - make


### PR DESCRIPTION
This is an early Travis CI script, but I tested it and made sure that it's functional!  Due to some issues that I'm not certain how to fix just yet, I disabled PHP and Ruby on the macOS builds for the time being (and I've got Travis to only build on macOS right now, as I need to try compiling TinySpline on Linux to determine the steps).

Want to get this running on the repository right away?  Before pulling this request, log in with your GitHub account on https://travis-ci.org/ and enable this repository.  Then pull, and Travis CI will start right away!

Travis CI is quite nice, in that it checks every branch and PR as well.  It sends you reports via email when a build fails, as well as when it's working again after failure!