### PR TITLE
Add packages to generate bindings on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler:
 osx_image: xcode9.2
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:timsc/swig-3.0.12; sudo apt-get -qq update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/php; brew update; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/php; brew update; fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install swig3.0 cmake -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install swig3.0 cmake python-dev ruby-dev php-dev liblua5.3-dev octave-pkg-dev -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install swig php71 lua; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/php; brew update; fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install swig3.0 cmake python-dev ruby-dev php-dev liblua5.3-dev octave-pkg-dev openjdk-8-jdk -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install swig3.0 cmake python-dev ruby-dev php-dev liblua50-dev octave-pkg-dev openjdk-8-jdk -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install swig php71 lua; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ compiler:
 
 osx_image: xcode9.2
 
-dist: xenial # May not work
+dist: xenial
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:timsc/swig-3.0.12 -y; sudo apt-get -qq update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ compiler:
 
 osx_image: xcode9.2
 
+dist: xenial # May not work
+
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:timsc/swig-3.0.12 -y; sudo apt-get -qq update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/php; brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/php; brew update; fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install swig3.0 cmake python-dev ruby-dev php-dev liblua5.3-dev octave-pkg-dev -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install swig3.0 cmake python-dev ruby-dev php-dev liblua5.3-dev octave-pkg-dev openjdk-8-jdk -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install swig php71 lua; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler:
 osx_image: xcode9.2
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:timsc/swig-3.0.12; sudo apt-get -qq update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:timsc/swig-3.0.12 -y; sudo apt-get -qq update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/php; brew update; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/php; brew update; fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install swig3.0 cmake python-dev ruby-dev php-dev liblua50-dev octave-pkg-dev openjdk-8-jdk -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install swig3.0 cmake python-dev ruby-dev php-dev liblua5.3-dev octave-pkg-dev openjdk-8-jdk -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install swig php71 lua; fi
 
 before_script:
   - mkdir build
   - cd build
-  - cmake ..
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]];then cmake ..; fi;
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cmake .. -DTINYSPLINE_WITH_PHP=FALSE -DTINYSPLINE_WITH_RUBY=FALSE; fi;
 
 script:
   - cmake --build .


### PR DESCRIPTION
All of the packages needed to generate the different bindings are now installed by Travis' Linux machines.  Please note, as #86 explains, Swig is out of date on APT and PHP cannot be generated and tested by Travis CI just yet.