### PR TITLE
Include multiple macOS and Linux versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,17 @@ compiler:
   - gcc
   - clang
 
-osx_image: xcode9.2
+osx_image:
+  - xcode9.2 # macOS 10.13 (High Sierra)
+  - xcode8.3 # macOS 10.12 (Sierra)
+  - xcode7.3 # macOS 10.11 (El Capitan)
+  - xcode6.4 # macOS 10.10 (Yosemite)
 
-dist: xenial
+dist:
+  - xenial
+  - zesty
+
+sudo: false
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:timsc/swig-3.0.12 -y; sudo apt-get -qq update; fi
@@ -23,7 +31,7 @@ install:
 before_script:
   - mkdir build
   - cd build
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]];then cmake ..; fi;
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cmake ..; fi;
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cmake .. -DTINYSPLINE_WITH_PHP=FALSE -DTINYSPLINE_WITH_RUBY=FALSE; fi;
 
 script:


### PR DESCRIPTION
This is to make sure it's functional on multiple different versions.  I chose the four macOS versions that Homebrew creates bottles* for, and are the four to support, as well as the two latest Ubuntu versions.

* A bottle is a compiled version of a package