### PR TITLE
Fix various documentation and misc. typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
 
 #### Prebuilt Binaries
 
-Comming soon.
+Coming soon.
 
 #### Compiling From Source
 TinySpline uses the CMake build system to compile and package its interfaces.

--- a/docs/mkdocs/docs/getting-started.md.in
+++ b/docs/mkdocs/docs/getting-started.md.in
@@ -1,7 +1,7 @@
 ## C++ Interface
 
 The following listing gives an example of TinySpline's C++ API. Depending on
-its configuration, _tinyspline::real_ reprsents either a _float_ or a _double_:
+its configuration, _tinyspline::real_ represents either a _float_ or a _double_:
 
 ```c++
 #include <iostream>

--- a/src/tinyspline.h
+++ b/src/tinyspline.h
@@ -969,7 +969,7 @@ void ts_deboornet_free(tsDeBoorNet *net);
  * On error, all values of \p \_spline\_ are set to 0/NULL.
  *
  * Note: \p n is the number of points in \p points and not the length of
- * \p points. For instance, the follwing point vector yields to \p n = 4 and
+ * \p points. For instance, the following point vector yields to \p n = 4 and
  * \p dim = 2:
  * 
  *     [x0, y0, x1, y1, x2, y2, x3, y3]
@@ -1093,7 +1093,7 @@ tsError ts_bspline_eval_all(const tsBSpline *spline, const tsReal *us,
  * @param points
  * 	The output parameter.
  * @param actual_num
- * 	The actual number of generated knots. Differs from \p num ony if \p num
+ * 	The actual number of generated knots. Differs from \p num only if \p num
  * 	is 0. Must not be NULL.
  * @param status
  * 	The status of this function. May be NULL.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-### Check if code coverage is availabe. Code coverage is measured and depicted
+### Check if code coverage is available. Code coverage is measured and depicted
 ### using gcov, lcov, and genthml. The following CMake variables may be useful
 ### for targets creating code coverage.
 #


### PR DESCRIPTION
Found via `codespell -q 3`