### PR TITLE
Use ASCII characters for "-" in tinyspline.c

### DIFF
--- a/src/tinyspline.c
+++ b/src/tinyspline.c
@@ -844,9 +844,9 @@ tsError ts_bspline_interpolate_cubic(const tsReal *points, size_t num_points,
 			}
 		}
 		for (i = 0; i < dimension; i++) {
-			/* 6 * S_{1} − S_{0} */
+			/* 6 * S_{1} - S_{0} */
 			d[i] -= points[i];
-			/* 6 * S_{n-1} − S_{n} */
+			/* 6 * S_{n-1} - S_{n} */
 			k = len_int_points - (i+1);
 			l = len_points - (i+1);
 			d[k] -= points[l];


### PR DESCRIPTION
Hi guys,

There are two non-ASCII characters used as "-" in `tinyspline.c`, which will introduce trouble for VC under Windows of languages other than English.

VC will use the system default locale to read the file instead of UTF-8.

Thanks.