### PR TITLE
Fix derive for degree == 1 and update unit test

### DIFF
--- a/src/tinyspline.c
+++ b/src/tinyspline.c
@@ -1472,18 +1472,13 @@ tsError ts_bspline_derive(const tsBSpline *spline, size_t n, tsReal epsilon,
 					k = i    *dim + j;
 					l = (i+1)*dim + j;
 					ctrlp[k] = ctrlp[l] - ctrlp[k];
-					/* The new control point (ctrlp[k]) of
-					 * a line (deg == 1) must not be scaled
-					 * with `p / (u{i+p+1} - u{i+1})`.*/
-					if (deg > 1) {
-						kid1 = knots[i+deg+1];
-						ki1  = knots[i+1];
-						span = kid1 - ki1;
-						if (span < TS_KNOT_EPSILON)
-							span = (tsReal) TS_KNOT_EPSILON;
-						ctrlp[k] *= deg;
-						ctrlp[k] /= span;
-					}
+					kid1 = knots[i+deg+1];
+					ki1  = knots[i+1];
+					span = kid1 - ki1;
+					if (span < TS_KNOT_EPSILON)
+						span = (tsReal) TS_KNOT_EPSILON;
+					ctrlp[k] *= deg;
+					ctrlp[k] /= span;
 				}
 			}
 			deg       -= 1;

--- a/test/c/derive.c
+++ b/test/c/derive.c
@@ -472,10 +472,10 @@ void derive_discontinuous_lines_ignoring_epsilon(CuTest *tc)
 		CuAssertIntEquals(tc, 2, (int)ts_deboornet_num_result(&net));
 		TS_CALL(try, status.code, ts_deboornet_result(
 			&net, &result, &status))
-		CuAssertDblEquals(tc,  1.0, result[0], EPSILON);
-		CuAssertDblEquals(tc,  1.0, result[1], EPSILON);
-		CuAssertDblEquals(tc, -2.0, result[2], EPSILON);
-		CuAssertDblEquals(tc, -2.0, result[3], EPSILON);
+		CuAssertDblEquals(tc,  1.0 / 0.7, result[0], EPSILON);
+		CuAssertDblEquals(tc,  1.0 / 0.7, result[1], EPSILON);
+		CuAssertDblEquals(tc, -2.0 / 0.3, result[2], EPSILON);
+		CuAssertDblEquals(tc, -2.0 / 0.3, result[3], EPSILON);
 	TS_CATCH(status.code)
 		CuFail(tc, status.message);
 	TS_FINALLY

--- a/test/c/derive.c
+++ b/test/c/derive.c
@@ -194,8 +194,8 @@ void derive_single_line_with_custom_knots(CuTest *tc)
 			(int) ts_bspline_num_control_points(&spline));
 		TS_CALL(try, status.code, ts_bspline_control_points(
 			&spline, &ctrlp, &status))
-		CuAssertDblEquals(tc, 1.f, ctrlp[0], EPSILON);
-		CuAssertDblEquals(tc, 4.f, ctrlp[1], EPSILON);
+		CuAssertDblEquals(tc, 2.f / 2.f, ctrlp[0], EPSILON);
+		CuAssertDblEquals(tc, 8.f / 2.f, ctrlp[1], EPSILON);
 
 		/* Check knots of derivative. */
 		CuAssertIntEquals(tc, 2,


### PR DESCRIPTION
The logic in derive was incorrectly avoiding scaling control points for `degree == 1`. This removes the unnecessary logic and updates the `derive_single_line_with_custom_knots` unit test to demonstrate successful computation of the correct derivatives.

This is not yet ready to merge as the `derive_discontinuous_lines_ignoring_epsilon` unit test is currently failing.