### PR TITLE
docs: fix simple typo, incresing -> increasing

### DIFF
--- a/src/parson.c
+++ b/src/parson.c
@@ -57,7 +57,7 @@
 #define STARTING_CAPACITY 16
 #define MAX_NESTING       2048
 
-#define FLOAT_FORMAT "%1.17g" /* do not increase precision without incresing NUM_BUF_SIZE */
+#define FLOAT_FORMAT "%1.17g" /* do not increase precision without increasing NUM_BUF_SIZE */
 #define NUM_BUF_SIZE 64 /* double printed with "%1.17g" shouldn't be longer than 25 bytes so let's be paranoid and use 64 */
 
 #define SIZEOF_TOKEN(a)       (sizeof(a) - 1)


### PR DESCRIPTION
There is a small typo in src/parson.c.

Should read `increasing` rather than `incresing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md