### PR TITLE
Rename `tinysplinecpp.h` to `tinysplinecxx.h`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The same example using the C++ interface:
 
 ```cpp
 #include <iostream>
-#include "tinysplinecpp.h"
+#include "tinysplinecxx.h"
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
An oversight of 85df516a5f69bef28338ec0a499c56bea05ba693.