### PR TITLE
Fix python build with debug binaries installed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1024,8 +1024,8 @@ endif()
 function (tinyspline_add_swig_library)
 	cmake_parse_arguments(ARGS
 		""
-		"TARGET;TYPE;LANG;OUTPUT;LIBS;NAME"
-		"SWIG_ARGS;FLAGS"
+                "TARGET;TYPE;LANG;OUTPUT;NAME"
+                "SWIG_ARGS;FLAGS;LIBS"
 		${ARGN})
 	set_source_files_properties("swig/${ARGS_TARGET}.i"
 		PROPERTIES CPLUSPLUS ON)


### PR DESCRIPTION
Issue happens when you have debug libraries installed to python.

How to reproduce:

1. Install any python version INCLUDING DEBUG LIBRARIES
1. Clone tinyspline
1. Enable `CXX` and `PYTHON` targets
1. Run cmake
1. Obsereve cmake error: `The "optimized" argument must be followed by a library`
![qtcreator_Pw1XF61eub](https://user-images.githubusercontent.com/8058622/168560455-ce04072e-91cf-42df-bcd3-31c1c1e5a6ee.png)

To overcome this, I moved `LIBS` argument of `cmake_parse_arguments` to `multi_value_keywords` instead of `one_value_keywords` arg.

Resulting target is linked to a proper dll, depending on current configuration:
![DependenciesGui_UmfsE9DSGP](https://user-images.githubusercontent.com/8058622/168561684-892687f6-62c9-4c0b-b011-363911175f02.png)

---
Didn't tested this change on other targets, but for python probably makes sense to start using `FindPython2` and `FindPython3` instead of deprecated `FindPythonLibs`
